### PR TITLE
Update .editorconfig to comply with PSR-12

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,6 @@
 # This file is for unifying the coding style for different editors and IDEs
 # editorconfig.org
 
-# WordPress Coding Standards for PHP files
-# https://make.wordpress.org/core/handbook/coding-standards/
-
 root = true
 
 [*]
@@ -14,7 +11,8 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
-[functions.php]
+# PSR-12 uses indent of 4 spaces
+[*.php]
 indent_size = 4
 
 [*.md]


### PR DESCRIPTION
PSR-12 Coding Style needs 4 spaces for indenting. According to that, updated the conflicting `.editorconfig`.
Source: https://www.php-fig.org/psr/psr-12/#24-indenting